### PR TITLE
Add Multilayer Perceptron Regression

### DIFF
--- a/src/main/scala/org/apache/spark/ml/scaladl/MultilayerPerceptronRegressor.scala
+++ b/src/main/scala/org/apache/spark/ml/scaladl/MultilayerPerceptronRegressor.scala
@@ -99,9 +99,6 @@ private object RegressionLabelConverter {
       output(0)
     }
   }
-//
-//  override val uid: String = Identifiable.randomUID("Regression Converter")
-//  override def copy(extra: ParamMap): MultilayerPerceptronRegressor = defaultCopy(extra)
 }
 
  /**

--- a/src/main/scala/org/apache/spark/ml/scaladl/MultilayerPerceptronRegressor.scala
+++ b/src/main/scala/org/apache/spark/ml/scaladl/MultilayerPerceptronRegressor.scala
@@ -136,6 +136,36 @@ class MultilayerPerceptronRegressor (
     with MultilayerPerceptronParams with MultilayerPerceptronRegressorParams with Serializable
     with DefaultParamsWritable {
 
+   /** @group setParam */
+   def setLayers(value: Array[Int]): this.type = set(layers, value)
+
+   /** @group setParam */
+   def setBlockSize(value: Int): this.type = set(blockSize, value)
+
+   /**
+    * Set the maximum number of iterations.
+    * Default is 100.
+    *
+    * @group setParam
+    */
+   def setMaxIter(value: Int): this.type = set(maxIter, value)
+
+   /**
+    * Set the convergence tolerance of iterations.
+    * Smaller value will lead to higher accuracy with the cost of more iterations.
+    * Default is 1E-4.
+    *
+    * @group setParam
+    */
+   def setTol(value: Double): this.type = set(tol, value)
+
+   /**
+    * Set the seed for weights initialization if weights are not set
+    *
+    * @group setParam
+    */
+   def setSeed(value: Long): this.type = set(seed, value)
+
   /**
    * Sets the value of param [[initialWeights]].
    *
@@ -145,7 +175,7 @@ class MultilayerPerceptronRegressor (
 
   /**
    * Sets the value of param [[optimizer]].
-   * Default is "l-bfgs".
+   * Default is "LBFGS".
    *
    * @group expertSetParam
    */
@@ -175,6 +205,8 @@ class MultilayerPerceptronRegressor (
     // Compute minimum and maximum values in the training labels for scaling.
     val minmax = dataset
       .agg(max("label").cast(DoubleType), min("label").cast(DoubleType)).collect()(0)
+    setMin(minmax(1).asInstanceOf[Double])
+    setMax(minmax(0).asInstanceOf[Double])
     // Encode and scale labels to prepare for training.
     val data = lpData.map(lp =>
       RegressionLabelConverter.encodeLabeledPoint(lp, minmax(1).asInstanceOf[Double],
@@ -188,11 +220,11 @@ class MultilayerPerceptronRegressor (
     } else {
       trainer.setSeed($(seed))
     }
-     if ($(optimizer) == MultilayerPerceptronRegressor.LBFGS) {
+     if (getOptimizer == "LBFGS") {
        trainer.LBFGSOptimizer
          .setConvergenceTol($(tol))
          .setNumIterations($(maxIter))
-     } else if ($(optimizer) == MultilayerPerceptronRegressor.GD) {
+     } else if (getOptimizer == "GD") {
        trainer.SGDOptimizer
          .setNumIterations($(maxIter))
          .setConvergenceTol($(tol))

--- a/src/main/scala/org/apache/spark/ml/scaladl/MultilayerPerceptronRegressor.scala
+++ b/src/main/scala/org/apache/spark/ml/scaladl/MultilayerPerceptronRegressor.scala
@@ -1,0 +1,409 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.scaladl
+
+import scala.collection.JavaConverters._
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.ml.{PredictionModel, Predictor, PredictorParams}
+import org.apache.spark.ml.feature.LabeledPoint
+import org.apache.spark.ml.linalg.{Vector, Vectors}
+import org.apache.spark.ml.param._
+import org.apache.spark.ml.param.shared._
+import org.apache.spark.ml.util._
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.functions.{max, min}
+import org.apache.spark.sql.types._
+
+import scaladl.layers.{FeedForwardTopology, FeedForwardTrainer}
+
+
+/** Params for Multilayer Perceptron. */
+private[ml] trait MultilayerPerceptronBasicParams extends PredictorParams
+  with HasSeed with HasMaxIter with HasTol with HasStepSize {
+   /**
+    * Layer sizes including input size and output size.
+    *
+    * @group param
+    */
+  final val layers: IntArrayParam = new IntArrayParam(this, "layers",
+    "Sizes of layers including input and output from bottom to the top." +
+      " E.g., Array(780, 100, 10) means 780 inputs, " +
+      "hidden layer with 100 neurons and output layer of 10 neurons.",
+     (t: Array[Int]) => t.forall(ParamValidators.gt(0)) && t.length > 1
+  )
+
+  /** @group setParam */
+  def setLayers(value: Array[Int]): this.type = set(layers, value)
+
+  /** @group getParam */
+  final def getLayers: Array[Int] = $(layers)
+
+  /**
+   * Block size for stacking input data in matrices. Speeds up the computations.
+   * Cannot be more than the size of the dataset.
+   *
+   * @group expertParam
+   */
+  final val blockSize: IntParam = new IntParam(this, "blockSize",
+    "Block size for stacking input data in matrices.",
+    ParamValidators.gt(0))
+
+  /** @group setParam */
+  def setBlockSize(value: Int): this.type = set(blockSize, value)
+
+  /** @group getParam */
+  final def getBlockSize: Int = $(blockSize)
+
+  /**
+   * The solver algorithm for optimization.
+   * Supported options: "gd" (minibatch gradient descent) or "l-bfgs".
+   * Default: "l-bfgs"
+   *
+   * @group expertParam
+   */
+  final val solver: Param[String] = new Param[String](this, "solver",
+    "The solver algorithm for optimization. Supported options: " +
+      s"${MultilayerPerceptronRegressor.supportedSolvers.mkString(", ")}. (Default l-bfgs)",
+    ParamValidators.inArray[String](MultilayerPerceptronRegressor.supportedSolvers))
+
+  /** @group expertGetParam */
+  final def getSolver: String = $(solver)
+
+  /**
+   * Param indicating whether to scale the labels to be between 0 and 1.
+   *
+   * @group param
+   */
+  final val stdLabels: BooleanParam = new BooleanParam(
+    this, "stdLabels", "Whether to standardize the dataset's labels to between 0 and 1.")
+
+  /** @group getParam */
+  def setStandardizeLabels(value: Boolean): this.type = set(stdLabels, value)
+
+  /** @group getParam */
+  def getStandardizeLabels: Boolean = $(stdLabels)
+
+  /**
+   * Set the maximum number of iterations.
+   * Default is 100.
+   *
+   * @group setParam
+   */
+  def setMaxIter(value: Int): this.type = set(maxIter, value)
+
+  /**
+   * Set the convergence tolerance of iterations.
+   * Smaller value will lead to higher accuracy with the cost of more iterations.
+   * Default is 1E-4.
+   *
+   * @group setParam
+   */
+  def setTol(value: Double): this.type = set(tol, value)
+
+  /**
+   * Set the seed for weights initialization.
+   * Default is 11L.
+   *
+   * @group setParam
+   */
+  def setSeed(value: Long): this.type = set(seed, value)
+
+  /**
+   * The initial weights of the model.
+   *
+   * @group expertParam
+   */
+  final val initialWeights: Param[Vector] = new Param[Vector](this, "initialWeights",
+    "The initial weights of the model")
+
+  /** @group expertGetParam */
+  final def getInitialWeights: Vector = $(initialWeights)
+
+  setDefault(seed -> 11L, maxIter -> 100, stdLabels -> true, tol -> 1e-4, layers -> Array(1, 1),
+    solver -> MultilayerPerceptronRegressor.LBFGS, stepSize -> 0.03, blockSize -> 128)
+}
+
+ /**
+  * Params that need to mixin with both MultilayerPerceptronRegressorModel and
+  * MultilayerPerceptronRegressor
+  */
+private[ml] trait MultilayerPerceptronRegressorParams extends PredictorParams {
+
+  final val minimum: DoubleParam = new DoubleParam(this, "min",
+    "Minimum value for scaling data.")
+
+  /**
+   * Set the minimum value in the training set labels.
+   *
+   * @group setParam
+   */
+  def setMin(value: Double): this.type = set(minimum, value)
+
+  /** @group getParam */
+  final def getMin: Double = $(minimum)
+
+  final val maximum: DoubleParam = new DoubleParam(this, "max",
+    "Max value for scaling data.")
+
+  /**
+   * Set the maximum value in the training set labels.
+   *
+   * @group setParam
+   */
+  def setMax(value: Double): this.type = set(maximum, value)
+
+  /** @group getParam */
+  final def getMax: Double = $(maximum)
+
+  setDefault(minimum -> 0.0, maximum -> 0.0)
+}
+
+/** Label to vector converter. */
+private object RegressionLabelConverter {
+
+  /**
+   * Encodes a label as a vector.
+   * Returns a vector of length 1 with the label in the 0th position
+   *
+   * @param labeledPoint labeled point
+   * @return pair of features and vector encoding of a label
+   */
+  def encodeLabeledPoint(labeledPoint: LabeledPoint, min: Double, max: Double): (Vector, Vector) = {
+    val output = Array.fill(1)(0.0)
+    if (max-min != 0.0) {
+      output(0) = (labeledPoint.label - min) / (max - min)
+    }
+    else {
+    // When min and max are equal, cannot min-max scale due to divide by zero error. Setting scaled
+    // result to zero will lead to consistent predictions, as the min will be added during decoding.
+    // Min and max will both be 0 if label scaling is turned off, and this code branch will run.
+      output(0) = labeledPoint.label - min
+    }
+    (labeledPoint.features, Vectors.dense(output))
+  }
+
+  /**
+   * Converts a vector to a label.
+   * Returns the value of the 0th element of the output vector.
+   *
+   * @param output label encoded with a vector
+   * @return label
+   */
+  def decodeLabel(output: Vector, min: Double, max: Double): Double = {
+    if (max-min != 0.0) {
+      (output(0) * (max - min)) + min
+    } else {
+      output(0)
+    }
+  }
+}
+
+ /**
+  * :: Experimental ::
+  * Regression trainer based on Multi-layer perceptron regression.
+  * Contains sigmoid activation function on all layers, output layer has a linear function.
+  * Number of inputs has to be equal to the size of feature vectors.
+  * Number of outputs has to be equal to one.
+  */
+class MultilayerPerceptronRegressor (
+    override val uid: String)
+  extends Predictor[Vector, MultilayerPerceptronRegressor, MultilayerPerceptronRegressorModel]
+    with MultilayerPerceptronBasicParams with MultilayerPerceptronRegressorParams with Serializable
+    with DefaultParamsWritable {
+
+  /**
+   * Sets the value of param [[initialWeights]].
+   *
+   * @group expertSetParam
+   */
+  def setInitialWeights(value: Vector): this.type = set(initialWeights, value)
+
+  /**
+   * Sets the value of param [[solver]].
+   * Default is "l-bfgs".
+   *
+   * @group expertSetParam
+   */
+  def setSolver(value: String): this.type = set(solver, value)
+
+  /**
+   * Sets the value of param [[stepSize]] (applicable only for solver "gd").
+   * Default is 0.03.
+   *
+   * @group setParam
+   */
+  def setStepSize(value: Double): this.type = set(stepSize, value)
+
+  def this() = this(Identifiable.randomUID("mlpr"))
+
+  override def copy(extra: ParamMap): MultilayerPerceptronRegressor = defaultCopy(extra)
+
+  /**
+   * Train a model using the given dataset and parameters.
+   *
+   * @param dataset Training dataset
+   * @return Fitted model
+   */
+  override protected def train(dataset: Dataset[_]): MultilayerPerceptronRegressorModel = {
+    val myLayers = getLayers
+    val lpData: RDD[LabeledPoint] = extractLabeledPoints(dataset)
+    if (getStandardizeLabels) {
+      // Compute minimum and maximum values in the training labels for scaling.
+      val minmax = dataset
+        .agg(max("label").cast(DoubleType), min("label").cast(DoubleType)).collect()(0)
+      setMin(minmax(1).asInstanceOf[Double])
+      setMax(minmax(0).asInstanceOf[Double])
+    }
+    // Encode and scale labels to prepare for training.
+    val data = lpData.map(lp =>
+      RegressionLabelConverter.encodeLabeledPoint(lp, $(minimum), $(maximum)))
+    // Initialize the network architecture with the specified layer count and sizes.
+    val topology = FeedForwardTopology.multiLayerPerceptronRegression(myLayers)
+    // Prepare the Network trainer based on our settings.
+    val trainer = new FeedForwardTrainer(topology, myLayers(0), myLayers.last)
+    if (isDefined(initialWeights)) {
+      trainer.setWeights($(initialWeights))
+    } else {
+      trainer.setSeed($(seed))
+    }
+     if ($(solver) == MultilayerPerceptronRegressor.LBFGS) {
+       trainer.LBFGSOptimizer
+         .setConvergenceTol($(tol))
+         .setNumIterations($(maxIter))
+     } else if ($(solver) == MultilayerPerceptronRegressor.GD) {
+       trainer.SGDOptimizer
+         .setNumIterations($(maxIter))
+         .setConvergenceTol($(tol))
+         .setStepSize($(stepSize))
+     } else {
+       throw new IllegalArgumentException(
+         s"The solver $solver is not supported by MultilayerPerceptronRegressor.")
+     }
+    trainer.setStackSize($(blockSize))
+    // Train Model.
+    val mlpModel = trainer.train(data)
+    new MultilayerPerceptronRegressorModel(uid, myLayers, mlpModel.weights)
+  }
+}
+
+
+object MultilayerPerceptronRegressor
+  extends DefaultParamsReadable[MultilayerPerceptronRegressor] {
+
+  /** String name for "l-bfgs" solver. */
+  private[ml] val LBFGS = "l-bfgs"
+
+  /** String name for "gd" (minibatch gradient descent) solver. */
+  private[ml] val GD = "gd"
+
+  /** Set of solvers that MultilayerPerceptronRegressor supports. */
+  private[ml] val supportedSolvers = Array(LBFGS, GD)
+
+  override def load(path: String): MultilayerPerceptronRegressor = super.load(path)
+}
+
+
+/**
+ * :: Experimental ::
+ * Multi-layer perceptron regression model.
+ * Each layer has sigmoid activation function, output layer has softmax.
+ *
+ * @param uid uid
+ * @param layers array of layer sizes including input and output
+ * @param weights weights (or parameters) of the model
+ * @return prediction model
+ */
+class MultilayerPerceptronRegressorModel private[ml] (
+    override val uid: String,
+    val layers: Array[Int],
+    val weights: Vector)
+  extends PredictionModel[Vector, MultilayerPerceptronRegressorModel]
+    with Serializable with MultilayerPerceptronRegressorParams with MLWritable {
+
+  override val numFeatures: Int = layers.head
+
+  private val mlpModel =
+    FeedForwardTopology.multiLayerPerceptronRegression(layers).model(weights)
+
+  /** Returns layers in a Java List. */
+  private[ml] def javaLayers: java.util.List[Int] = layers.toList.asJava
+
+  /**
+   * Predict label for the given features.
+   * This internal method is used to implement [[transform()]] and output [[predictionCol]].
+   */
+  override def predict(features: Vector): Double = {
+    RegressionLabelConverter.decodeLabel(mlpModel.predict(features), $(minimum), $(maximum))
+  }
+
+  override def copy(extra: ParamMap): MultilayerPerceptronRegressorModel = {
+    copyValues(new MultilayerPerceptronRegressorModel(uid, layers, weights), extra)
+  }
+
+  override def write: MLWriter =
+  new MultilayerPerceptronRegressorModel.MultilayerPerceptronRegressorModelWriter(this)
+}
+
+object MultilayerPerceptronRegressorModel
+  extends MLReadable[MultilayerPerceptronRegressorModel] {
+
+  override def read: MLReader[MultilayerPerceptronRegressorModel] =
+    new MultilayerPerceptronRegressorModelReader
+
+  override def load(path: String): MultilayerPerceptronRegressorModel = super.load(path)
+
+  /** [[MLWriter]] instance for [[MultilayerPerceptronRegressorModel]] */
+  private[MultilayerPerceptronRegressorModel]
+  class MultilayerPerceptronRegressorModelWriter(
+    instance: MultilayerPerceptronRegressorModel) extends MLWriter {
+
+    private case class Data(layers: Array[Int], weights: Vector)
+
+    override protected def saveImpl(path: String): Unit = {
+      // Save metadata and Params
+      DefaultParamsWriter.saveMetadata(instance, path, sc)
+      // Save model data: layers, weights
+      val data = Data(instance.layers, instance.weights)
+      val dataPath = new Path(path, "data").toString
+      sqlContext.createDataFrame(Seq(data)).repartition(1).write.parquet(dataPath)
+    }
+  }
+
+  private class MultilayerPerceptronRegressorModelReader
+    extends MLReader[MultilayerPerceptronRegressorModel] {
+
+    /** Checked against metadata when loading model */
+    private val className = classOf[MultilayerPerceptronRegressorModel].getName
+
+    override def load(path: String): MultilayerPerceptronRegressorModel = {
+      val metadata = DefaultParamsReader.loadMetadata(path, sc, className)
+
+      val dataPath = new Path(path, "data").toString
+      val data = sqlContext.read.parquet(dataPath).select("layers", "weights").head()
+      val layers = data.getAs[Seq[Int]](0).toArray
+      val weights = data.getAs[Vector](1)
+      val model = new MultilayerPerceptronRegressorModel(metadata.uid, layers, weights)
+
+      DefaultParamsReader.getAndSetParams(model, metadata)
+      model
+    }
+  }
+}

--- a/src/main/scala/scaladl/layers/Layer.scala
+++ b/src/main/scala/scaladl/layers/Layer.scala
@@ -239,46 +239,6 @@ private[layers] class SigmoidFunction extends ActivationFunction {
 }
 
 /**
- * Implements Linear activation function
- */
-private[layers] class LinearFunction extends ActivationFunction {
-
-  override def eval: (Double) => Double = x => x
-
-  override def derivative: (Double) => Double = z => 1
-}
-
-/**
- * Implements relu activation function
- */
-private[layers] class ReluFunction extends ActivationFunction {
-
-  override def eval: (Double) => Double = x => {
-    if (x > 0) x
-    else 0
-  }
-
-  override def derivative: (Double) => Double = z => {
-    if (z > 0) 1
-    else 0
-  }
-}
-
-/**
- * Implements tanh activation function
- */
-private[layers] class TanhFunction extends ActivationFunction {
-
-  override def eval: (Double) => Double = x => {
-    ( 2 / (1 + math.exp(-2 * x))) - 1
-  }
-
-  override def derivative: (Double) => Double = z => {
-    1 - math.pow((( 2 / (1 + math.exp(-2 * z))) - 1), 2)
-  }
-}
-
-/**
  * Functional layer properties, y = f(x)
  *
  * @param activationFunction activation function
@@ -436,9 +396,9 @@ object FeedForwardTopology {
       layers(i * 2) = new AffineLayer(layerSizes(i), layerSizes(i + 1))
       layers(i * 2 + 1) =
         if (i == layerSizes.length - 2) {
-          new LinearLayerWithSquaredError()
+          new EmptyLayerWithSquaredError()
         } else {
-          new FunctionalLayer(new TanhFunction())
+          new FunctionalLayer(new SigmoidFunction())
         }
     }
     FeedForwardTopology(layers)
@@ -691,9 +651,9 @@ private[layers] class ANNUpdater extends Updater {
  * @param outputSize output size
  */
 class FeedForwardTrainer(
-                                      topology: Topology,
-                                      val inputSize: Int,
-                                      val outputSize: Int) extends Serializable {
+    topology: Topology,
+    val inputSize: Int,
+    val outputSize: Int) extends Serializable {
 
   private var _seed = 11L
   private var _weights: Vector = null

--- a/src/main/scala/scaladl/layers/Layer.scala
+++ b/src/main/scala/scaladl/layers/Layer.scala
@@ -239,6 +239,46 @@ private[layers] class SigmoidFunction extends ActivationFunction {
 }
 
 /**
+ * Implements Linear activation function
+ */
+private[layers] class LinearFunction extends ActivationFunction {
+
+  override def eval: (Double) => Double = x => x
+
+  override def derivative: (Double) => Double = z => 1
+}
+
+/**
+ * Implements relu activation function
+ */
+private[layers] class ReluFunction extends ActivationFunction {
+
+  override def eval: (Double) => Double = x => {
+    if (x > 0) x
+    else 0
+  }
+
+  override def derivative: (Double) => Double = z => {
+    if (z > 0) 1
+    else 0
+  }
+}
+
+/**
+ * Implements tanh activation function
+ */
+private[layers] class TanhFunction extends ActivationFunction {
+
+  override def eval: (Double) => Double = x => {
+    ( 2 / (1 + math.exp(-2 * x))) - 1
+  }
+
+  override def derivative: (Double) => Double = z => {
+    1 - math.pow((( 2 / (1 + math.exp(-2 * z))) - 1), 2)
+  }
+}
+
+/**
  * Functional layer properties, y = f(x)
  *
  * @param activationFunction activation function
@@ -364,8 +404,7 @@ object FeedForwardTopology {
    *                Softmax is default
    * @return multilayer perceptron topology
    */
-  def multiLayerPerceptron(
-                            layerSizes: Array[Int],
+  def multiLayerPerceptron(layerSizes: Array[Int],
                             softmaxOnTop: Boolean = true): FeedForwardTopology = {
     val layers = new Array[Layer]((layerSizes.length - 1) * 2)
     for(i <- 0 until layerSizes.length - 1) {
@@ -380,6 +419,26 @@ object FeedForwardTopology {
           }
         } else {
           new FunctionalLayer(new SigmoidFunction())
+        }
+    }
+    FeedForwardTopology(layers)
+  }
+
+  /**
+   * Creates a multi-layer perceptron for regression
+   *
+   * @param layerSizes sizes of layers including input and output size
+   * @return multilayer perceptron topology
+   */
+  def multiLayerPerceptronRegression(layerSizes: Array[Int]): FeedForwardTopology = {
+    val layers = new Array[Layer]((layerSizes.length - 1) * 2)
+    for (i <- 0 until layerSizes.length - 1) {
+      layers(i * 2) = new AffineLayer(layerSizes(i), layerSizes(i + 1))
+      layers(i * 2 + 1) =
+        if (i == layerSizes.length - 2) {
+          new LinearLayerWithSquaredError()
+        } else {
+          new FunctionalLayer(new TanhFunction())
         }
     }
     FeedForwardTopology(layers)

--- a/src/main/scala/scaladl/layers/LossFunction.scala
+++ b/src/main/scala/scaladl/layers/LossFunction.scala
@@ -37,26 +37,6 @@ private[layers] trait LossFunction {
   def loss(output: Tensor, target: Tensor, delta: Tensor): Double
 }
 
-private[layers] class LinearLayerWithSquaredError extends Layer {
-  override val weightSize = 0
-  override val inPlace = true
-
-  override def outputSize(inputSize: Int): Int = inputSize
-  override def model(weights: Tensor): LayerModel =
-    new LinearLayerModelWithSquaredError()
-  override def initModel(weights: Tensor, random: Random): LayerModel =
-    new LinearLayerModelWithSquaredError()
-}
-
-private[layers] class LinearLayerModelWithSquaredError
-  extends FunctionalLayerModel(new FunctionalLayer(new LinearFunction)) with LossFunction {
-  override def loss(output: Tensor, target: Tensor, delta: Tensor): Double = {
-    DenseTensor.applyFunction(output, target, delta, (o: Double, t: Double) => o - t)
-    val error = (delta :* delta).sum / 2 / output.shape(1)
-    error
-  }
-}
-
 class SigmoidLayerWithSquaredError extends Layer {
   override val weightSize = 0
   override def outputSize(inputSize: Int): Int = inputSize

--- a/src/main/scala/scaladl/layers/LossFunction.scala
+++ b/src/main/scala/scaladl/layers/LossFunction.scala
@@ -37,6 +37,26 @@ private[layers] trait LossFunction {
   def loss(output: Tensor, target: Tensor, delta: Tensor): Double
 }
 
+private[layers] class LinearLayerWithSquaredError extends Layer {
+  override val weightSize = 0
+  override val inPlace = true
+
+  override def outputSize(inputSize: Int): Int = inputSize
+  override def model(weights: Tensor): LayerModel =
+    new LinearLayerModelWithSquaredError()
+  override def initModel(weights: Tensor, random: Random): LayerModel =
+    new LinearLayerModelWithSquaredError()
+}
+
+private[layers] class LinearLayerModelWithSquaredError
+  extends FunctionalLayerModel(new FunctionalLayer(new LinearFunction)) with LossFunction {
+  override def loss(output: Tensor, target: Tensor, delta: Tensor): Double = {
+    DenseTensor.applyFunction(output, target, delta, (o: Double, t: Double) => o - t)
+    val error = (delta :* delta).sum / 2 / output.shape(1)
+    error
+  }
+}
+
 class SigmoidLayerWithSquaredError extends Layer {
   override val weightSize = 0
   override def outputSize(inputSize: Int): Int = inputSize


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a pull request adding support for Multilayer Perceptron Regression, the counterpart to the Multilayer Perceptron Classifier (hereafter MLPR and MLPC). 
#### Outline
1. Major Changes
2. API Decisions
3. Automating Scaling
4. Features
5. Reference Resources
## Major Changes

There are two major differences between MLPR and MLPC. The first is the use of an linear (identity) activation function and a sum of squared error cost function in the last layer of the network. The second is the requirement to scale the data to [0,1] and back to make it easy for the weights to fit a value in the proper range. 
#### Linear, Relu, Tanh Activations

In the forward pass the linear activation passes the value from the fully connected layer through to become the network prediction. In weight adjustment during the backward pass its derivative is one. All regression models will use the linear activation in the last layer, and so there is no option (as there is in MLPC) to use another activation function and cost function in the last layer.

The Relu and Tanh are activation functions that will benefit the accuracy and convergence speed MLPC and MLPR. Tanh zero-centers the data passed to neurons which aids optimization. Relu avoids saturating the gradients.
#### Automated Scaling

The data scaling is done through min-max scaling, where the minimum label is subtracted from every value (leading to a range from [0 to max-min]) and then dividing by max-min to get a scale from 0 to 1. The corner case where max-min = 0 is resolved by omitting the division step. 
#### Motivating Example

<img width="1103" alt="screen shot 2016-09-29 at 4 17 23 pm" src="https://cloud.githubusercontent.com/assets/4738024/18975657/978477f2-8660-11e6-82f8-4b02490b91e9.png">
## API Decisions

The API is identical to MLPC with the exception of softmaxOnTop - there is no option on the last layer activation function, or on the cost function to be used (MLPC gives a choice between cross entropy and sum of square error). This API has the user call MLPR with a set of layers that represent the topology of the network. The number of hidden layers is inferred by the parameter for the labels and is equal to the total number of layers - 2. Each hidden layer will be a feedforward layer with a sigmoid activation function up to the output layer and its linear activation.
#### Input/Output Layer Argument

For MLPR, the output count will usually be 1, and the number of inputs will always be equal to the number of features in the training dataset. One API choice could be to omit the input and output counts and only have the user supply the number of neurons in the hidden layers, and automate the input and output counts by looking at the training data. At the very least, it makes sense to validate the user’s layer parameter and display a helpful error message instead of the error in the data stacker that currently appears if the improper number of inputs or outputs is provided.
#### Modular API

It also would make sense for the API to be modular. A user will want the flexibility to use the linear layer at different points in the network (as well as in MLPC), and will certainly want to be able to use new activation functions (tanh, relu) that are added to improve the performance of these models. That flexibility allows a user to tune the network to their dataset and will be particularly important for convnets or recurrent nets in future. We should decide on the best way to enable tanh and relu activations in this algorithm and in the classifier for the time being.
## Automating Scaling

Current behavior has an argument allowing the user to turn off scaling using MultilayerPerceptronRegressor().setStandardizeLabels(false).

In general I advocate for helpful defaults that can be overridden, where we scale automatically but give an option to run without scaling and don’t run autoscaling if both the min and max are provided by the user.
## Features

There are a few features that have been checked:
1. Integrates cleanly with pipeline API
2. Model save/load is enabled
## Reference Resources

Christopher M. Bishop. Neural Networks for Pattern Recognition.
Patrick Nicolas. Scala for Machine Learning, Chapter 9.
Ian Goodfellow Yoshua Bengio and Aaron Courville. Deep Learning, Chapter 6.
